### PR TITLE
Add NGC_SINGULARITY_MODULE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Some of the expected changes are:
 
 1. The name of the Singularity module. The container environment
    modules try to load the `Singularity` module (note the capital
-   'S'). Modify this if the local Singularity module is named
-   differently.
+   'S'). Set the `NGC_SINGULARITY_MODULE` environment variable if the
+   local Singularity module is named differently (set it to `none` if
+   no Singularity module is required).
 
 2. Module conflicts. The container environment modules set module
    conflicts based on the commands mapped into the container. Sites

--- a/autodock/2020.06.lua
+++ b/autodock/2020.06.lua
@@ -39,8 +39,11 @@ whatis("Version: 2020.06")
 whatis("Description: The AutoDock Suite is a growing collection of methods for computational docking and virtual screening, for use in structure-based drug discovery and exploration of the basic mechanisms of biomolecular structure and function. ")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:autodock")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName())

--- a/chroma/2018-cuda9.0-ubuntu16.04-volta-openmpi.lua
+++ b/chroma/2018-cuda9.0-ubuntu16.04-volta-openmpi.lua
@@ -40,8 +40,11 @@ whatis("Version: 2018-cuda9.0-ubuntu16.04-volta-openmpi")
 whatis("Description: The Chroma package provides a toolbox and executables to carry out calculation of lattice Quantum Chromodynamics (LQCD). It is built on top of the QDP++ (QCD Data Parallel Layer) which provides an abstract data parallel view of the lattice and provides lattice wide types and expressions, using expression templates, to allow straightforward encoding of LQCD equations.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:chroma")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "lammps", "milc", "qmcpack", "relion")

--- a/chroma/2020.06.lua
+++ b/chroma/2020.06.lua
@@ -40,8 +40,11 @@ whatis("Version: 2020.06")
 whatis("Description: The Chroma package provides a toolbox and executables to carry out calculation of lattice Quantum Chromodynamics (LQCD). It is built on top of the QDP++ (QCD Data Parallel Layer) which provides an abstract data parallel view of the lattice and provides lattice wide types and expressions, using expression templates, to allow straightforward encoding of LQCD equations.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:chroma")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "lammps", "milc", "qmcpack", "relion")

--- a/gromacs/2018.2.lua
+++ b/gromacs/2018.2.lua
@@ -40,8 +40,11 @@ whatis("Version: 2018.2")
 whatis("Description: GROMACS is a molecular dynamics application designed to simulate Newtonian equations of motion for systems with hundreds to millions of particles. GROMACS is designed to simulate biochemical molecules like proteins, lipids, and nucleic acids that have a lot of complicated bonded interactions. More info on GROMACS can be found at http://www.gromacs.org/")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:gromacs")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName())

--- a/gromacs/2020.2.lua
+++ b/gromacs/2020.2.lua
@@ -40,8 +40,11 @@ whatis("Version: 2020.2")
 whatis("Description: GROMACS is a molecular dynamics application designed to simulate Newtonian equations of motion for systems with hundreds to millions of particles. GROMACS is designed to simulate biochemical molecules like proteins, lipids, and nucleic acids that have a lot of complicated bonded interactions. More info on GROMACS can be found at http://www.gromacs.org/")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:gromacs")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName())

--- a/julia/v1.5.0.lua
+++ b/julia/v1.5.0.lua
@@ -38,8 +38,11 @@ whatis("Version: v1.5.0")
 whatis("Description: The Julia programming language is a flexible dynamic language, appropriate for scientific and numerical computing, with performance comparable to traditional statically-typed languages.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:julia")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName())

--- a/lammps/15Jun2020.lua
+++ b/lammps/15Jun2020.lua
@@ -41,8 +41,11 @@ whatis("Version: 15Jun2020")
 whatis("Description: Large-scale Atomic/Molecular Massively Parallel Simulator (LAMMPS) is a software application designed for molecular dynamics simulations. It has potentials for solid-state materials (metals, semiconductor), soft matter (biomolecules, polymers) and coarse-grained or mesoscopic systems. It can be used to model atoms or, more generically, as a parallel particle simulator at the atomic, meso, or continuum scale.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:lammps")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "chroma", "milc", "qmcpack", "relion")

--- a/lammps/24Oct2018.lua
+++ b/lammps/24Oct2018.lua
@@ -41,8 +41,11 @@ whatis("Version: 24Oct2018")
 whatis("Description: Large-scale Atomic/Molecular Massively Parallel Simulator (LAMMPS) is a software application designed for molecular dynamics simulations. It has potentials for solid-state materials (metals, semiconductor), soft matter (biomolecules, polymers) and coarse-grained or mesoscopic systems. It can be used to model atoms or, more generically, as a parallel particle simulator at the atomic, meso, or continuum scale.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:lammps")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "chroma", "milc", "qmcpack", "relion")

--- a/lammps/29Oct2020.lua
+++ b/lammps/29Oct2020.lua
@@ -41,8 +41,11 @@ whatis("Version: 29Oct2020")
 whatis("Description: Large-scale Atomic/Molecular Massively Parallel Simulator (LAMMPS) is a software application designed for molecular dynamics simulations. It has potentials for solid-state materials (metals, semiconductor), soft matter (biomolecules, polymers) and coarse-grained or mesoscopic systems. It can be used to model atoms or, more generically, as a parallel particle simulator at the atomic, meso, or continuum scale.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:lammps")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "chroma", "milc", "qmcpack", "relion")

--- a/milc/quda0.8-patch4Oct2017.lua
+++ b/milc/quda0.8-patch4Oct2017.lua
@@ -41,8 +41,11 @@ whatis("Version: quda0.8-patch4Oct2017")
 whatis("Description: MILC represents part of a set of codes written by the MIMD Lattice Computation (MILC) collaboration used to study quantum chromodynamics (QCD), the theory of the strong interactions of subatomic physics. It performs simulations of four dimensional SU(3) lattice gauge theory on MIMD parallel machines. \"Strong interactions\" are responsible for binding quarks into protons and neutrons and holding them all together in the atomic nucleus.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:milc")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "chroma", "lammps", "qmcpack", "relion")

--- a/namd/2.13-multinode.lua
+++ b/namd/2.13-multinode.lua
@@ -39,8 +39,11 @@ whatis("Version: 2.13")
 whatis("Description: NAMD is a parallel molecular dynamics code designed for high-performance simulation of large biomolecular systems. NAMD uses the popular molecular graphics program VMD for simulation setup and trajectory analysis, but is also file-compatible with AMBER, CHARMM, and X-PLOR.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:namd")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName())

--- a/namd/2.13-singlenode.lua
+++ b/namd/2.13-singlenode.lua
@@ -39,8 +39,11 @@ whatis("Version: 2.13")
 whatis("Description: NAMD is a parallel molecular dynamics code designed for high-performance simulation of large biomolecular systems. NAMD uses the popular molecular graphics program VMD for simulation setup and trajectory analysis, but is also file-compatible with AMBER, CHARMM, and X-PLOR.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:namd")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName())

--- a/nvhpc/20.11.lua
+++ b/nvhpc/20.11.lua
@@ -45,8 +45,11 @@ whatis("Version: 20.11")
 whatis("The NVIDIA HPC SDK is a comprehensive suite of compilers, libraries and tools essential to maximizing developer productivity and the performance and portability of HPC applications. The NVIDIA HPC SDK C, C++, and Fortran compilers support GPU acceleration of HPC modeling and simulation applications with standard C++ and Fortran, OpenACC directives, and CUDA. GPU-accelerated math libraries maximize performance on common HPC algorithms, and optimized communications libraries enable standards-based multi-GPU and scalable systems programming. Performance profiling and debugging tools simplify porting and optimization of HPC applications, and containerization tools enable easy deployment on-premises or in the cloud.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:nvhpc")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "nvhpc")

--- a/nvhpc/20.7.lua
+++ b/nvhpc/20.7.lua
@@ -45,8 +45,11 @@ whatis("Version: 20.7")
 whatis("The NVIDIA HPC SDK is a comprehensive suite of compilers, libraries and tools essential to maximizing developer productivity and the performance and portability of HPC applications. The NVIDIA HPC SDK C, C++, and Fortran compilers support GPU acceleration of HPC modeling and simulation applications with standard C++ and Fortran, OpenACC directives, and CUDA. GPU-accelerated math libraries maximize performance on common HPC algorithms, and optimized communications libraries enable standards-based multi-GPU and scalable systems programming. Performance profiling and debugging tools simplify porting and optimization of HPC applications, and containerization tools enable easy deployment on-premises or in the cloud.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:nvhpc")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "nvhpc")

--- a/nvhpc/20.9.lua
+++ b/nvhpc/20.9.lua
@@ -45,8 +45,11 @@ whatis("Version: 20.9")
 whatis("The NVIDIA HPC SDK is a comprehensive suite of compilers, libraries and tools essential to maximizing developer productivity and the performance and portability of HPC applications. The NVIDIA HPC SDK C, C++, and Fortran compilers support GPU acceleration of HPC modeling and simulation applications with standard C++ and Fortran, OpenACC directives, and CUDA. GPU-accelerated math libraries maximize performance on common HPC algorithms, and optimized communications libraries enable standards-based multi-GPU and scalable systems programming. Performance profiling and debugging tools simplify porting and optimization of HPC applications, and containerization tools enable easy deployment on-premises or in the cloud.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:nvhpc")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "nvhpc")

--- a/pytorch/20.02-py3.lua
+++ b/pytorch/20.02-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.02-py3")
 whatis("Description: PyTorch is a GPU accelerated tensor computational framework with a Python front end. Functionality can be easily extended with common Python libraries such as NumPy, SciPy, and Cython. Automatic differentiation is done with a tape-based system at both a functional and neural network layer level. This functionality brings a high level of flexibility and speed as a deep learning framework and provides accelerated NumPy-like functionality.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:pytorch")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "tensorflow")

--- a/pytorch/20.03-py3.lua
+++ b/pytorch/20.03-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.03-py3")
 whatis("Description: PyTorch is a GPU accelerated tensor computational framework with a Python front end. Functionality can be easily extended with common Python libraries such as NumPy, SciPy, and Cython. Automatic differentiation is done with a tape-based system at both a functional and neural network layer level. This functionality brings a high level of flexibility and speed as a deep learning framework and provides accelerated NumPy-like functionality.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:pytorch")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "tensorflow")

--- a/pytorch/20.06-py3.lua
+++ b/pytorch/20.06-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.06-py3")
 whatis("Description: PyTorch is a GPU accelerated tensor computational framework with a Python front end. Functionality can be easily extended with common Python libraries such as NumPy, SciPy, and Cython. Automatic differentiation is done with a tape-based system at both a functional and neural network layer level. This functionality brings a high level of flexibility and speed as a deep learning framework and provides accelerated NumPy-like functionality.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:pytorch")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "tensorflow")

--- a/pytorch/20.11-py3.lua
+++ b/pytorch/20.11-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.11-py3")
 whatis("Description: PyTorch is a GPU accelerated tensor computational framework with a Python front end. Functionality can be easily extended with common Python libraries such as NumPy, SciPy, and Cython. Automatic differentiation is done with a tape-based system at both a functional and neural network layer level. This functionality brings a high level of flexibility and speed as a deep learning framework and provides accelerated NumPy-like functionality.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:pytorch")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "tensorflow")

--- a/pytorch/20.12-py3.lua
+++ b/pytorch/20.12-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.12-py3")
 whatis("Description: PyTorch is a GPU accelerated tensor computational framework with a Python front end. Functionality can be easily extended with common Python libraries such as NumPy, SciPy, and Cython. Automatic differentiation is done with a tape-based system at both a functional and neural network layer level. This functionality brings a high level of flexibility and speed as a deep learning framework and provides accelerated NumPy-like functionality.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:pytorch")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "tensorflow")

--- a/qmcpack/v3.5.0.lua
+++ b/qmcpack/v3.5.0.lua
@@ -45,8 +45,11 @@ whatis("Version: 3.5.0")
 whatis("Description: QMCPACK is an open-source, high-performance electronic structure code that implements numerous Quantum Monte Carlo algorithms. Its main applications are electronic structure calculations of molecular, periodic 2D and periodic 3D solid-state systems. Variational Monte Carlo (VMC), diffusion Monte Carlo (DMC) and a number of other advanced QMC algorithms are implemented. By directly solving the Schrodinger equation, QMC methods offer greater accuracy than methods such as density functional theory, but at a trade-off of much greater computational expense. Distinct from many other correlated many-body methods, QMC methods are readily applicable to both bulk (periodic) and isolated molecular systems.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:qmcpack")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "chroma", "lammps", "milc", "relion")

--- a/quantum_espresso/v6.6a1.lua
+++ b/quantum_espresso/v6.6a1.lua
@@ -38,8 +38,11 @@ whatis("Version: v6.6a1")
 whatis("Description: Quantum ESPRESSO is an integrated suite of Open-Source computer codes for electronic-structure calculations and materials modeling at the nanoscale based on density-functional theory, plane waves, and pseudopotentials.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:quantum_espresso")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "chroma", "lammps", "milc", "qmcpack", "relion")

--- a/rapidsai/0.12.lua
+++ b/rapidsai/0.12.lua
@@ -36,8 +36,11 @@ whatis("Version: 0.12")
 whatis("Description: The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes that GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia/rapidsai:rapidsai")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "pytorch", "tensorflow")

--- a/rapidsai/0.13.lua
+++ b/rapidsai/0.13.lua
@@ -36,8 +36,11 @@ whatis("Version: 0.13")
 whatis("Description: The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes that GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia/rapidsai:rapidsai")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "pytorch", "tensorflow")

--- a/rapidsai/0.14.lua
+++ b/rapidsai/0.14.lua
@@ -36,8 +36,11 @@ whatis("Version: 0.14")
 whatis("Description: The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes that GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia/rapidsai:rapidsai")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "pytorch", "tensorflow")

--- a/rapidsai/0.15.lua
+++ b/rapidsai/0.15.lua
@@ -36,8 +36,11 @@ whatis("Version: 0.15")
 whatis("Description: The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes that GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia/rapidsai:rapidsai")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "pytorch", "tensorflow")

--- a/rapidsai/0.16.lua
+++ b/rapidsai/0.16.lua
@@ -36,8 +36,11 @@ whatis("Version: 0.16")
 whatis("Description: The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes that GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia/rapidsai:rapidsai")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "pytorch", "tensorflow")

--- a/rapidsai/0.17.lua
+++ b/rapidsai/0.17.lua
@@ -36,8 +36,11 @@ whatis("Version: 0.17")
 whatis("Description: The RAPIDS suite of software libraries gives you the freedom to execute end-to-end data science and analytics pipelines entirely on GPUs. It relies on NVIDIA® CUDA® primitives for low-level compute optimization, but exposes that GPU parallelism and high-bandwidth memory speed through user-friendly Python interfaces.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia/rapidsai:rapidsai")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "pytorch", "tensorflow")

--- a/relion/2.1.b1.lua
+++ b/relion/2.1.b1.lua
@@ -40,8 +40,11 @@ whatis("Version: 2.1.b1")
 whatis("Description: RELION (for REgularized LIkelihood OptimizatioN) implements an empirical Bayesian approach for analysis of electron cryo-microscopy (Cryo-EM). Specifically it provides methods of refinement of singular or multiple 3D reconstructions as well as 2D class averages. RELION is an important tool in the study of living cells.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:relion")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "chroma", "lammps", "milc", "relion")

--- a/relion/3.0.8.lua
+++ b/relion/3.0.8.lua
@@ -40,8 +40,11 @@ whatis("Version: 3.0.8")
 whatis("Description: RELION (for REgularized LIkelihood OptimizatioN) implements an empirical Bayesian approach for analysis of electron cryo-microscopy (Cryo-EM). Specifically it provides methods of refinement of singular or multiple 3D reconstructions as well as 2D class averages. RELION is an important tool in the study of living cells.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:relion")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "chroma", "lammps", "milc", "relion")

--- a/relion/3.1.0.lua
+++ b/relion/3.1.0.lua
@@ -40,8 +40,11 @@ whatis("Version: 3.1.0")
 whatis("Description: RELION (for REgularized LIkelihood OptimizatioN) implements an empirical Bayesian approach for analysis of electron cryo-microscopy (Cryo-EM). Specifically it provides methods of refinement of singular or multiple 3D reconstructions as well as 2D class averages. RELION is an important tool in the study of living cells.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/hpc:relion")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "openmpi", "chroma", "lammps", "milc", "quantum_espresso", "relion")

--- a/tensorflow/20.02-tf1-py3.lua
+++ b/tensorflow/20.02-tf1-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.02-tf1-py3")
 whatis("Description: TensorFlow is an open-source software library for numerical computation using data flow graphs. Nodes in the graph represent mathematical operations, while the graph edges represent the multidimensional data arrays (tensors) that flow between them. This flexible architecture lets you deploy computation to one or more CPUs or GPUs in a desktop, server, or mobile device without rewriting code.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "pytorch")

--- a/tensorflow/20.02-tf2-py3.lua
+++ b/tensorflow/20.02-tf2-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.02-tf2-py3")
 whatis("Description: TensorFlow is an open-source software library for numerical computation using data flow graphs. Nodes in the graph represent mathematical operations, while the graph edges represent the multidimensional data arrays (tensors) that flow between them. This flexible architecture lets you deploy computation to one or more CPUs or GPUs in a desktop, server, or mobile device without rewriting code.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "pytorch")

--- a/tensorflow/20.03-tf1-py3.lua
+++ b/tensorflow/20.03-tf1-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.03-tf1-py3")
 whatis("Description: TensorFlow is an open-source software library for numerical computation using data flow graphs. Nodes in the graph represent mathematical operations, while the graph edges represent the multidimensional data arrays (tensors) that flow between them. This flexible architecture lets you deploy computation to one or more CPUs or GPUs in a desktop, server, or mobile device without rewriting code.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "pytorch")

--- a/tensorflow/20.03-tf2-py3.lua
+++ b/tensorflow/20.03-tf2-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.03-tf2-py3")
 whatis("Description: TensorFlow is an open-source software library for numerical computation using data flow graphs. Nodes in the graph represent mathematical operations, while the graph edges represent the multidimensional data arrays (tensors) that flow between them. This flexible architecture lets you deploy computation to one or more CPUs or GPUs in a desktop, server, or mobile device without rewriting code.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "pytorch")

--- a/tensorflow/20.06-tf1-py3.lua
+++ b/tensorflow/20.06-tf1-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.06-tf1-py3")
 whatis("Description: TensorFlow is an open-source software library for numerical computation using data flow graphs. Nodes in the graph represent mathematical operations, while the graph edges represent the multidimensional data arrays (tensors) that flow between them. This flexible architecture lets you deploy computation to one or more CPUs or GPUs in a desktop, server, or mobile device without rewriting code.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "pytorch")

--- a/tensorflow/20.06-tf2-py3.lua
+++ b/tensorflow/20.06-tf2-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.06-tf2-py3")
 whatis("Description: TensorFlow is an open-source software library for numerical computation using data flow graphs. Nodes in the graph represent mathematical operations, while the graph edges represent the multidimensional data arrays (tensors) that flow between them. This flexible architecture lets you deploy computation to one or more CPUs or GPUs in a desktop, server, or mobile device without rewriting code.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "pytorch")

--- a/tensorflow/20.11-tf1-py3.lua
+++ b/tensorflow/20.11-tf1-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.11-tf1-py3")
 whatis("Description: TensorFlow is an open-source software library for numerical computation using data flow graphs. Nodes in the graph represent mathematical operations, while the graph edges represent the multidimensional data arrays (tensors) that flow between them. This flexible architecture lets you deploy computation to one or more CPUs or GPUs in a desktop, server, or mobile device without rewriting code.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "pytorch")

--- a/tensorflow/20.11-tf2-py3.lua
+++ b/tensorflow/20.11-tf2-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.11-tf2-py3")
 whatis("Description: TensorFlow is an open-source software library for numerical computation using data flow graphs. Nodes in the graph represent mathematical operations, while the graph edges represent the multidimensional data arrays (tensors) that flow between them. This flexible architecture lets you deploy computation to one or more CPUs or GPUs in a desktop, server, or mobile device without rewriting code.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "pytorch")

--- a/tensorflow/20.12-tf1-py3.lua
+++ b/tensorflow/20.12-tf1-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.12-tf1-py3")
 whatis("Description: TensorFlow is an open-source software library for numerical computation using data flow graphs. Nodes in the graph represent mathematical operations, while the graph edges represent the multidimensional data arrays (tensors) that flow between them. This flexible architecture lets you deploy computation to one or more CPUs or GPUs in a desktop, server, or mobile device without rewriting code.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "pytorch")

--- a/tensorflow/20.12-tf2-py3.lua
+++ b/tensorflow/20.12-tf2-py3.lua
@@ -41,8 +41,11 @@ whatis("Version: 20.12-tf2-py3")
 whatis("Description: TensorFlow is an open-source software library for numerical computation using data flow graphs. Nodes in the graph represent mathematical operations, while the graph edges represent the multidimensional data arrays (tensors) that flow between them. This flexible architecture lets you deploy computation to one or more CPUs or GPUs in a desktop, server, or mobile device without rewriting code.")
 whatis("URL: https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow")
 
-if not (isloaded("Singularity")) then
-    load("Singularity")
+if not (os.getenv("NGC_SINGULARITY_MODULE") == "none") then
+	local singularity_module = os.getenv("NGC_SINGULARITY_MODULE") or "Singularity"
+	if not (isloaded(singularity_module)) then
+		load(singularity_module)
+	end
 end
 
 conflict(myModuleName(), "rapidsai", "pytorch")


### PR DESCRIPTION
Add a new environment variable `NGC_SINGULARITY_MODULE` to set the name of the Singularity module to load.

If the variable is not set, then load `Singularity`.

If the variable is set to `none`, skip loading any Singularity module.

If the variable is set to `X`, then load `X`.

Fixes #2.