### PR TITLE
Stop aliasing relion GUI command in Relion 3.*

### DIFF
--- a/relion/3.0.8.lua
+++ b/relion/3.0.8.lua
@@ -51,7 +51,7 @@ conflict(myModuleName(), "openmpi", "chroma", "lammps", "milc", "relion")
 
 local image = "nvcr.io_hpc_relion:3.0.8.sif"
 local uri = "docker://nvcr.io/hpc/relion:3.0.8"
-local programs = {"mpirun", "relion", "relion_refine_mpi"}
+local programs = {"mpirun", "relion_refine_mpi"}
 local entrypoint_args = ""
 
 -- The absolute path to Singularity is needed so it can be invoked on remote

--- a/relion/3.1.0.lua
+++ b/relion/3.1.0.lua
@@ -51,7 +51,7 @@ conflict(myModuleName(), "openmpi", "chroma", "lammps", "milc", "quantum_espress
 
 local image = "nvcr.io_hpc_relion:3.1.0.sif"
 local uri = "docker://nvcr.io/hpc/relion:3.1.0"
-local programs = {"mpirun", "relion", "relion_refine_mpi"}
+local programs = {"mpirun", "relion_refine_mpi"}
 local entrypoint_args = ""
 
 -- The absolute path to Singularity is needed so it can be invoked on remote

--- a/relion/3.1.2.lua
+++ b/relion/3.1.2.lua
@@ -51,7 +51,7 @@ conflict(myModuleName(), "openmpi", "chroma", "lammps", "milc", "quantum_espress
 
 local image = "nvcr.io_hpc_relion:3.1.2.sif"
 local uri = "docker://nvcr.io/hpc/relion:3.1.2"
-local programs = {"mpirun", "relion", "relion_refine_mpi"}
+local programs = {"mpirun", "relion_refine_mpi"}
 local entrypoint_args = ""
 
 -- The absolute path to Singularity is needed so it can be invoked on remote


### PR DESCRIPTION
In Relion-3 containers the GUI was removed from container for size
considerations (https://forums.developer.nvidia.com/t/relion-3-containers-lack-the-relion-gui/173632).