### PR TITLE
Quote CLI arguments in bash version of the function

### DIFF
--- a/autodock/2020.06.lua
+++ b/autodock/2020.06.lua
@@ -84,6 +84,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/chroma/2018-cuda9.0-ubuntu16.04-volta-openmpi.lua
+++ b/chroma/2018-cuda9.0-ubuntu16.04-volta-openmpi.lua
@@ -88,6 +88,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/chroma/2020.06.lua
+++ b/chroma/2020.06.lua
@@ -88,6 +88,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/chroma/2021.04.lua
+++ b/chroma/2021.04.lua
@@ -88,6 +88,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/gromacs/2018.2.lua
+++ b/gromacs/2018.2.lua
@@ -82,6 +82,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/gromacs/2020.2.lua
+++ b/gromacs/2020.2.lua
@@ -82,6 +82,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/gromacs/2021.lua
+++ b/gromacs/2021.lua
@@ -82,6 +82,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/julia/v1.5.0.lua
+++ b/julia/v1.5.0.lua
@@ -82,6 +82,6 @@ local container_launch = singularity .. " run --nv -B $HOME/.julia:/data " .. im
 -- Programs to setup in the shell
 -- julia is the container entrypoint
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " $@",
+        set_shell_function(program, container_launch .. " \"$@\"",
 	                            container_launch .. " $*")
 end

--- a/julia/v2.4.2.lua
+++ b/julia/v2.4.2.lua
@@ -82,6 +82,6 @@ local container_launch = singularity .. " run --nv -B $HOME/.julia:/data " .. im
 -- Programs to setup in the shell
 -- julia is the container entrypoint
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " $@",
+        set_shell_function(program, container_launch .. " \"$@\"",
 	                            container_launch .. " $*")
 end

--- a/lammps/15Jun2020.lua
+++ b/lammps/15Jun2020.lua
@@ -86,6 +86,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/lammps/24Oct2018.lua
+++ b/lammps/24Oct2018.lua
@@ -87,6 +87,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/lammps/29Oct2020.lua
+++ b/lammps/29Oct2020.lua
@@ -86,6 +86,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/milc/quda0.8-patch4Oct2017.lua
+++ b/milc/quda0.8-patch4Oct2017.lua
@@ -87,6 +87,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/namd/2.13-multinode.lua
+++ b/namd/2.13-multinode.lua
@@ -82,7 +82,7 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end
 

--- a/namd/2.13-singlenode.lua
+++ b/namd/2.13-singlenode.lua
@@ -82,7 +82,7 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end
 

--- a/namd/3.0-alpha3-singlenode.lua
+++ b/namd/3.0-alpha3-singlenode.lua
@@ -82,7 +82,7 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end
 

--- a/nvhpc/20.11.lua
+++ b/nvhpc/20.11.lua
@@ -90,6 +90,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/nvhpc/20.7.lua
+++ b/nvhpc/20.7.lua
@@ -90,6 +90,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/nvhpc/20.9.lua
+++ b/nvhpc/20.9.lua
@@ -90,6 +90,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/nvhpc/21.5.lua
+++ b/nvhpc/21.5.lua
@@ -90,6 +90,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/pytorch/20.02-py3.lua
+++ b/pytorch/20.02-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/pytorch/20.03-py3.lua
+++ b/pytorch/20.03-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/pytorch/20.06-py3.lua
+++ b/pytorch/20.06-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/pytorch/20.11-py3.lua
+++ b/pytorch/20.11-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/pytorch/20.12-py3.lua
+++ b/pytorch/20.12-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/pytorch/21.06-py3.lua
+++ b/pytorch/21.06-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/qmcpack/v3.5.0.lua
+++ b/qmcpack/v3.5.0.lua
@@ -95,6 +95,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/quantum_espresso/v6.6a1.lua
+++ b/quantum_espresso/v6.6a1.lua
@@ -83,6 +83,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/quantum_espresso/v6.7.lua
+++ b/quantum_espresso/v6.7.lua
@@ -83,6 +83,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/rapidsai/0.12.lua
+++ b/rapidsai/0.12.lua
@@ -81,6 +81,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/rapidsai/0.13.lua
+++ b/rapidsai/0.13.lua
@@ -81,6 +81,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/rapidsai/0.14.lua
+++ b/rapidsai/0.14.lua
@@ -81,6 +81,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/rapidsai/0.15.lua
+++ b/rapidsai/0.15.lua
@@ -81,6 +81,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/rapidsai/0.16.lua
+++ b/rapidsai/0.16.lua
@@ -81,6 +81,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/rapidsai/0.17.lua
+++ b/rapidsai/0.17.lua
@@ -81,6 +81,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/rapidsai/21.06.lua
+++ b/rapidsai/21.06.lua
@@ -81,6 +81,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/relion/2.1.b1.lua
+++ b/relion/2.1.b1.lua
@@ -85,6 +85,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/relion/3.0.8.lua
+++ b/relion/3.0.8.lua
@@ -85,6 +85,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/relion/3.1.0.lua
+++ b/relion/3.1.0.lua
@@ -85,6 +85,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/relion/3.1.2.lua
+++ b/relion/3.1.2.lua
@@ -85,6 +85,6 @@ setenv("OMPI_MCA_orte_launch_agent", container_launch .. " orted")
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/20.02-tf1-py3.lua
+++ b/tensorflow/20.02-tf1-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/20.02-tf2-py3.lua
+++ b/tensorflow/20.02-tf2-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/20.03-tf1-py3.lua
+++ b/tensorflow/20.03-tf1-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/20.03-tf2-py3.lua
+++ b/tensorflow/20.03-tf2-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/20.06-tf1-py3.lua
+++ b/tensorflow/20.06-tf1-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/20.06-tf2-py3.lua
+++ b/tensorflow/20.06-tf2-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/20.11-tf1-py3.lua
+++ b/tensorflow/20.11-tf1-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/20.11-tf2-py3.lua
+++ b/tensorflow/20.11-tf2-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/20.12-tf1-py3.lua
+++ b/tensorflow/20.12-tf1-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/20.12-tf2-py3.lua
+++ b/tensorflow/20.12-tf2-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/21.06-tf1-py3.lua
+++ b/tensorflow/21.06-tf1-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end

--- a/tensorflow/21.06-tf2-py3.lua
+++ b/tensorflow/21.06-tf2-py3.lua
@@ -83,6 +83,6 @@ local container_launch = singularity .. " run --nv " .. image .. " " .. entrypoi
 
 -- Programs to setup in the shell
 for i,program in pairs(programs) do
-        set_shell_function(program, container_launch .. " " .. program .. " $@",
+        set_shell_function(program, container_launch .. " " .. program .. " \"$@\"",
 	                            container_launch .. " " .. program .. " $*")
 end


### PR DESCRIPTION
Otherwise complex multi-word command lines like
```
    module load tensorflow
    python -c "import tensorflow as tf; print(tf.__version__)"
```
fail in Bash.  The Tcsh branch works fine (only the Bash function was affected).